### PR TITLE
:sparkles: add --dry-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The bot automatically only runs once. To run the bot regulary, set the
 - `--interval=<seconds>` set polling interval in seconds. Minimum allowed: 15s.
 - `--tag=<tag name>` only check candidates with a tag. E.g. _Bot-Test_
 - `-d` delete Repository at the end of successfull homework creation
+- `--dry-run` don't perform any actions, just log what the bot would have done
 
 Possible homeworks have to be entered in the recruitee profile field form to be
 selectable.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,13 @@ import Bot from "./bot/bot.ts";
 import HealthchecksIO from "./monitoring/healthchecksio.ts";
 
 const args = parse(Deno.args, {
-  default: { o: false, tagRequired: undefined, d: false },
+  default: { o: false, tagRequired: undefined, d: false, "dry-run": false },
 });
 
 const pollingIntervalInS: number = Math.max(args.interval, 15);
 const tagRequired: string | undefined = args.tag;
 const deleteProjectInTheEnd: boolean = args.d;
+const dryRun = args["dry-run"];
 
 const {
   GITLAB_TOKEN,
@@ -61,6 +62,7 @@ const bot = new Bot(
   healthchecksIO,
   deleteProjectInTheEnd,
   tagRequired,
+  dryRun,
 );
 
 if (args.interval == undefined) {


### PR DESCRIPTION
Im dry-run Modus werden keine Kandidaten bearbeitet, sondern es wird nur geloggt wo etwas passiert wäre. Das ist ganz praktisch zum Testen wenn man gerade unsicher ist ob man den Bot gefahrlos starten kann oder ob irgendwo eine Task zu viel hängt.