### PR TITLE
Error while forking with consecutive special characters

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -8,7 +8,7 @@ import {
   CandidateSingleLineField,
   Task,
 } from "../recruitee/types.ts";
-import { addDaysToDate } from "../tools.ts";
+import { addDaysToDate, sanitizeRepositoryName } from "../tools.ts";
 import { isDropdownField, isSingleLineField } from "./../recruitee/tools.ts";
 import { EmojiErrorCodes } from "../errormojis.ts";
 import { RecruiteeError } from "../recruitee/RecruiteeError.ts";
@@ -442,10 +442,6 @@ export default class Bot {
     );
   }
 
-  private sanitizeRepositoryName(repositoryName: string): string {
-    return repositoryName.replace(/[-_]{2,}/, "");
-  }
-
   private async createHomeworkProjectFork(
     candidate: Candidate,
     gitlabUser: GitlabUser,
@@ -454,7 +450,7 @@ export default class Bot {
   ): Promise<{ issue: Issue; fork: GitlabProject; dueDate: Date }> {
     const homeworkProject = await this.gitlab.getTemplateProject(homework);
 
-    const forkName = this.sanitizeRepositoryName(
+    const forkName = sanitizeRepositoryName(
       `homework-${gitlabUser.username}-${
         Math.floor(
           Math.random() * 1000000000000,

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -24,6 +24,7 @@ export const GITLAB_USERNAME_FIELD_NAME = "GitLab Account";
 export const GITLAB_REPO_FIELD_NAME = "GitLab Repo";
 const GITHUB_BASE_URL = "https://gitlab.com/";
 const DEFAULT_HOMEWORK_DURATION_IN_DAYS = 8;
+const ILLEGAL_START_AND_END_CHARACTERS_FOR_USERNAME_IN_REPOSITORY = ["-", "_"];
 export const TASK_ASSIGN_MK_TEXT = "MK bilden und zuordnen";
 
 export default class Bot {
@@ -450,8 +451,15 @@ export default class Bot {
   ): Promise<{ issue: Issue; fork: GitlabProject; dueDate: Date }> {
     const homeworkProject = await this.gitlab.getTemplateProject(homework);
 
-    // ugly fix which should be done in a more proper way
-    const tmpUser = gitlabUser.username.replace("_", "");
+    // ensure the username for the repository does not contain any of the "illegal" characters
+    let tmpUser = gitlabUser.username;
+    for (
+      const illigalCharacter
+        in ILLEGAL_START_AND_END_CHARACTERS_FOR_USERNAME_IN_REPOSITORY
+    ) {
+      tmpUser = tmpUser.replace(illigalCharacter, "");
+    }
+
     const forkName = `homework-${tmpUser}-${
       Math.floor(
         Math.random() * 1000000000000,

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -443,6 +443,17 @@ export default class Bot {
     );
   }
 
+  private getCleanUsernameForRepository(gitlabUser: GitlabUser): string {
+    let tmpUser = gitlabUser.username;
+    for (
+      const illigalCharacter
+        in ILLEGAL_START_AND_END_CHARACTERS_FOR_USERNAME_IN_REPOSITORY
+    ) {
+      tmpUser = tmpUser.replace(illigalCharacter, "");
+    }
+    return tmpUser;
+  }
+
   private async createHomeworkProjectFork(
     candidate: Candidate,
     gitlabUser: GitlabUser,
@@ -451,16 +462,9 @@ export default class Bot {
   ): Promise<{ issue: Issue; fork: GitlabProject; dueDate: Date }> {
     const homeworkProject = await this.gitlab.getTemplateProject(homework);
 
-    // ensure the username for the repository does not contain any of the "illegal" characters
-    let tmpUser = gitlabUser.username;
-    for (
-      const illigalCharacter
-        in ILLEGAL_START_AND_END_CHARACTERS_FOR_USERNAME_IN_REPOSITORY
-    ) {
-      tmpUser = tmpUser.replace(illigalCharacter, "");
-    }
-
-    const forkName = `homework-${tmpUser}-${
+    const forkName = `homework-${
+      this.getCleanUsernameForRepository(gitlabUser)
+    }-${
       Math.floor(
         Math.random() * 1000000000000,
       )

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.100.0/testing/asserts.ts";
-import { addDaysToDate, dateToISO } from "./tools.ts";
+import { addDaysToDate, dateToISO, sanitizeRepositoryName } from "./tools.ts";
 
 Deno.test("addDaysToDate correctly adds given number of days", () => {
   const actual = addDaysToDate(new Date("2018-05-13"), 2);
@@ -19,4 +19,23 @@ Deno.test("addDaysToDate correctly changes year", () => {
 Deno.test("dateToISO correctly converts date from Date", () => {
   const actual = dateToISO(new Date("2018-05-13"));
   assertEquals(actual, "2018-05-13");
+});
+
+Deno.test("sanitizeRepositoryName correctly sanatizes a repository name", () => {
+  assertEquals(
+    sanitizeRepositoryName("homework-someUser-rand"),
+    "homework-someUser-rand",
+  );
+  assertEquals(
+    sanitizeRepositoryName("homework-someUser_-rand"),
+    "homework-someUser-rand",
+  );
+  assertEquals(
+    sanitizeRepositoryName("homework-someUser--rand"),
+    "homework-someUser-rand",
+  );
+  assertEquals(
+    sanitizeRepositoryName("homework-someUser___-rand"),
+    "homework-someUser-rand",
+  );
 });

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -19,5 +19,5 @@ export function sleep(seconds: number): Promise<void> {
 }
 
 export function sanitizeRepositoryName(repositoryName: string): string {
-  return repositoryName.replace(/[-_]{2,}/, "");
+  return repositoryName.replace(/[-_]{2,}/, "-");
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -17,3 +17,7 @@ export function sleep(seconds: number): Promise<void> {
     setTimeout(resolve, seconds * 1000);
   });
 }
+
+export function sanitizeRepositoryName(repositoryName: string): string {
+  return repositoryName.replace(/[-_]{2,}/, "");
+}


### PR DESCRIPTION
If a username contains a starting or ending "special" character, the generated name for the new reposptry will be `homework-username_-random`which causes the GitLab API to respond with an 409 error. This patch will fix that issue by sanatizing the repository name before trying to do the actual forking.